### PR TITLE
ProfilePicture in choreLeaderboard

### DIFF
--- a/forttask/src/components/chores/choreLeaderboard.tsx
+++ b/forttask/src/components/chores/choreLeaderboard.tsx
@@ -85,7 +85,7 @@ export default function ChoreLeaderboard({ refresh }: ChoreLeaderboardProps) {
         };
 
         fetchData();
-    }, [refresh, session]);
+    }, [refresh, session?.user?.householdId]);
 
     return (
         <div className="flex flex-col w-1/4 h-fit justify-center items-start rounded-xl border border-zinc-800 bg-zinc-950 mb-2 p-6">


### PR DESCRIPTION
nic tu dodac nic ujac bombastic fantastic 
This pull request enhances the `ChoreLeaderboard` component by integrating user profile data, replacing the `ProfilePicture` component with dynamic images, and improving error handling and data fetching logic. The changes focus on providing a richer user experience by displaying profile pictures and merging leaderboard data with user profiles.

### Enhancements to data handling and user experience:

* Introduced a `UserProfile` type and updated the `leaderboardData` type to include an optional `profilePicture` field. This allows the leaderboard to display profile pictures alongside usernames.
* Added a default profile picture (`DEFAULT_PROFILE_PICTURE`) to ensure a fallback image is displayed when a user does not have a profile picture.
* Updated the data fetching logic to retrieve both leaderboard data and user profiles. Merged the two datasets to associate each user with their profile picture, improving the visual representation of the leaderboard.

### UI improvements:

* Replaced the `ProfilePicture` component with the `Image` component from `next/image` to dynamically render user profile pictures in the leaderboard. This ensures better performance and flexibility in handling images.
* Enhanced the layout and styling of the leaderboard items to include profile pictures and ensure a consistent and visually appealing design.

### Session-based functionality:

* Integrated the `useSession` hook from `next-auth` to fetch user-specific data, such as household profiles, based on the logged-in user's session. This ensures personalized data is displayed in the leaderboard.
ide jesc obiad