### PR TITLE
Event n Chores API Unit Tests

### DIFF
--- a/forttask/src/app/api/chore/create/route.ts
+++ b/forttask/src/app/api/chore/create/route.ts
@@ -89,6 +89,6 @@ export async function POST(req: Request) {
         return NextResponse.json(completeChore, { status: 201 });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/forttask/src/app/api/chore/delete/route.ts
+++ b/forttask/src/app/api/chore/delete/route.ts
@@ -11,6 +11,10 @@ export async function DELETE(req: Request) {
             return NextResponse.json({ message: 'You must be logged in to delete chores' }, { status: 401 });
         }
 
+        if (!session.user?.householdId) {
+            return NextResponse.json({ message: 'You must be part of a household to delete chores' }, { status: 401 });
+        }
+
         const body = await req.json();
         const { choreId } = body;
 
@@ -31,6 +35,6 @@ export async function DELETE(req: Request) {
         return NextResponse.json({ message: 'Chore deleted successfully', chore });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/forttask/src/app/api/chore/done/route.ts
+++ b/forttask/src/app/api/chore/done/route.ts
@@ -11,6 +11,10 @@ export async function PUT(req: Request) {
             return NextResponse.json({message: 'You must be logged in to modify chores'}, {status: 401});
         }
 
+        if (!session.user?.householdId) {
+            return NextResponse.json({message: 'You must be part of a household to modify chores'}, {status: 401});
+        }
+
         const userId = parseInt(session.user.id);
 
         const body = await req.json();
@@ -37,6 +41,6 @@ export async function PUT(req: Request) {
         return NextResponse.json({message: 'Chore marked as done', chore});
     } catch (error) {
         console.error(error);
-        return NextResponse.json({error: 'Invalid request'}, {status: 400});
+        return NextResponse.json({error: 'Internal Server Error'}, {status: 500});
     }
 }

--- a/forttask/src/app/api/chore/todo/route.ts
+++ b/forttask/src/app/api/chore/todo/route.ts
@@ -11,6 +11,10 @@ export async function PUT(req: Request) {
             return NextResponse.json({message: 'You must be logged in to modify chores'}, {status: 401});
         }
 
+        if (!session.user?.householdId) {
+            return NextResponse.json({message: 'You must be part of a household to modify chores'}, {status: 401});
+        }
+
         const body = await req.json();
         const {choreId} = body;
 
@@ -35,6 +39,6 @@ export async function PUT(req: Request) {
         return NextResponse.json({message: 'Chore marked as not done', chore});
     } catch (error) {
         console.error(error);
-        return NextResponse.json({error: 'Invalid request'}, {status: 400});
+        return NextResponse.json({error: 'Internal Server Error'}, {status: 500});
     }
 }

--- a/forttask/src/app/api/chores/done/get/route.ts
+++ b/forttask/src/app/api/chores/done/get/route.ts
@@ -55,6 +55,6 @@ export async function GET(req: Request) {
         });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({error: 'Invalid request'}, {status: 400});
+        return NextResponse.json({error: 'Internal Server Error'}, {status: 500});
     }
 }

--- a/forttask/src/app/api/chores/todo/get/route.ts
+++ b/forttask/src/app/api/chores/todo/get/route.ts
@@ -55,6 +55,6 @@ export async function GET(req: Request) {
         });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({error: 'Invalid request'}, {status: 400});
+        return NextResponse.json({error: 'Internal Server Error'}, {status: 500});
     }
 }

--- a/forttask/src/app/api/event/create/route.ts
+++ b/forttask/src/app/api/event/create/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: Request) {
 
         const body = (await req.json()) as {
             name: string;
-            description?: string;
+            description: string;
             date: string;
             attendees: number[];
             location: string;
@@ -33,7 +33,7 @@ export async function POST(req: Request) {
         const newEvent = await prisma.event.create({
             data: {
                 name: body.name,
-                description: body.description || '',
+                description: body.description,
                 date: new Date(body.date),
                 householdId: householdId,
                 createdById: userId,
@@ -66,7 +66,7 @@ export async function POST(req: Request) {
 
                 childEvents.push({
                     name: body.name,
-                    description: body.description || '',
+                    description: body.description,
                     date: nextDate,
                     householdId: householdId,
                     createdById: userId,
@@ -116,6 +116,6 @@ export async function POST(req: Request) {
         return NextResponse.json(completeEvent, { status: 201 });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/forttask/src/app/api/event/create/route.ts
+++ b/forttask/src/app/api/event/create/route.ts
@@ -9,13 +9,13 @@ export async function POST(req: Request) {
         const session = await getServerSession(authOptions);
 
         if (!session || !session.user?.id) {
-            return NextResponse.json({ message: 'You must be logged in to view events' }, { status: 401 });
+            return NextResponse.json({ message: 'You must be logged in to create events' }, { status: 401 });
         }
 
         const userId = parseInt(session.user.id);
 
         if (!session.user?.householdId) {
-            return NextResponse.json({ message: 'You must be part of a household to create events' }, { status: 401 });
+            return NextResponse.json({ message: 'You must be a part of a household to create events' }, { status: 401 });
         }
 
         const householdId = parseInt(session.user.householdId);

--- a/forttask/src/app/api/event/delete/route.ts
+++ b/forttask/src/app/api/event/delete/route.ts
@@ -11,10 +11,14 @@ export async function DELETE(req: Request) {
             return NextResponse.json({ message: 'You must be logged in to delete events' }, { status: 401 });
         }
 
+        if (!session.user?.householdId) {
+            return NextResponse.json({ message: 'You must be a part of a household to delete events' }, { status: 401 });
+        }
+
         const householdId = session.user.householdId ? parseInt(session.user.householdId) : null;
 
-        const { searchParams } = new URL(req.url);
-        const eventId = searchParams.get('eventId');
+        const body = await req.json();
+        const { eventId } = body;
 
         if (!eventId) {
             return NextResponse.json({ error: 'Missing eventId parameter' }, { status: 400 });

--- a/forttask/src/app/api/event/delete/route.ts
+++ b/forttask/src/app/api/event/delete/route.ts
@@ -47,6 +47,6 @@ export async function DELETE(req: Request) {
         return new NextResponse(null, { status: 204 });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Server error' }, { status: 500 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/forttask/src/app/api/events/get/route.ts
+++ b/forttask/src/app/api/events/get/route.ts
@@ -13,6 +13,10 @@ export async function GET(req: Request) {
 
         const userId = parseInt(session.user.id);
 
+        if (!session.user?.householdId) {
+            return NextResponse.json({ message: 'You must be a part of a household to view events' }, { status: 401 });
+        }
+
         const url = new URL(req.url)
         const searchParams = url.searchParams;
         const date = searchParams.get('date');

--- a/forttask/src/app/api/events/get/route.ts
+++ b/forttask/src/app/api/events/get/route.ts
@@ -54,6 +54,6 @@ export async function GET(req: Request) {
         return NextResponse.json({ events, count });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/forttask/src/components/chores/choreDoneCard.tsx
+++ b/forttask/src/components/chores/choreDoneCard.tsx
@@ -160,14 +160,14 @@ export default function ChoreDoneCard({ chore, emitUpdate }: ChoreCardProps) {
                         });
 
                         if (!response.ok) {
-                            throw new Error('Failed to mark chore as undone');
+                            throw new Error('Failed to mark chore as todo');
                         }
 
                         if (emitUpdate) {
                             emitUpdate();
                         }
                     } catch (error) {
-                        console.error('Error marking chore as undone:', error);
+                        console.error('Error marking chore as todo:', error);
                     }
                 }}
                 onCancel={() => {

--- a/forttask/src/components/events/eventCard.tsx
+++ b/forttask/src/components/events/eventCard.tsx
@@ -165,8 +165,12 @@ export default function EventCard({ event, emitUpdate }: EventCardProps) {
                     document.body.removeChild(confirmationBox);
 
                     try {
-                        const response = await fetch(`/api/event/delete?eventId=${event.id}`, {
+                        const response = await fetch(`/api/event/delete`, {
                             method: 'DELETE',
+                            headers: {
+                                'Content-Type': 'application/json'
+                            },
+                            body: JSON.stringify({ eventId: event.id })
                         });
                         if (!response.ok) {
                             throw new Error(`Failed to delete event: ${response.status}`);

--- a/forttask/test/event.test.ts
+++ b/forttask/test/event.test.ts
@@ -1,190 +1,440 @@
-import { expect, test, vi } from 'vitest';
-import { POST, GET, DELETE } from '@/app/api/events/route';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../src/app/api/events/get/route';
+import { POST } from '../src/app/api/event/create/route';
+import { DELETE } from '../src/app/api/event/delete/route';
 import prisma from '../libs/__mocks__/prisma';
+import { getServerSession } from 'next-auth/next';
 
 vi.mock('../libs/prisma');
+vi.mock('next-auth/next', () => ({
+    getServerSession: vi.fn(),
+}));
 
-test('POST Event with correct data should return new Event and status 201', async () => {
-    const mockEvent = {
-        name: 'Test Event',
-        description: 'Test Description',
-        date: '2023-10-01',
-        attendees: [1, 2],
-        householdId: 1,
-        createdById: 1,
+type MockSession = {
+    user?: {
+        id?: string;
+        householdId?: string;
+    };
+    expires?: string;
+};
+
+type MockRequestOptions = {
+    searchParams?: Record<string, string>;
+    body?: Record<string, unknown>;
+};
+
+type User = {
+    id: number;
+    username: string;
+}
+
+type EventAttendee = {
+    userId: number;
+    eventId: number;
+    user: User;
+}
+
+type Event = {
+    id: number;
+    name: string;
+    description: string;
+    date: Date;
+    createdById: number;
+    attendees: EventAttendee[];
+    location: string;
+    cycle: number;
+    createdAt: Date;
+    householdId: number;
+    updatedAt: Date;
+    repeatCount: number;
+    parentEventId: number | null;
+}
+
+describe('Event GET API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const { searchParams = {}, body = {} } = options;
+
+        const url = new URL('http://localhost:3000/api/events/get');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body)
+        } as unknown as Request;
     };
 
-    const req = new Request('http://localhost/api/event', {
-        method: 'POST',
-        body: JSON.stringify(mockEvent),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+    it('should return 401 if user is not authenticated', async () => {
+        vi.mocked(getServerSession).mockResolvedValue(null);
+
+        const req = createMockRequest({ searchParams: {} });
+        const response = await GET(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(401);
+        expect(responseBody).toEqual({ message: 'You must be logged in to view events' });
     });
 
-    const mockResponse = { ...mockEvent, id: 1 };
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.event.create.mockResolvedValue(mockResponse);
+    it('should return 401 if user is not part of a household', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1' },
+        } as MockSession);
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+        const req = createMockRequest({ searchParams: {} });
+        const response = await GET(req);
+        const responseBody = await response.json();
 
-    expect(response.status).toBe(201);
-    expect(data).toStrictEqual(mockResponse);
-});
+        expect(response.status).toBe(401);
+        expect(responseBody).toEqual({ message: 'You must be a part of a household to view events' });
+    })
 
-test('POST Event with missing fields should return 400', async () => {
-    const req = new Request('http://localhost/api/event', {
-        method: 'POST',
-        body: JSON.stringify({}),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+    it('should return events for the authenticated user', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
+
+        const req = createMockRequest({ searchParams: { date: '2023-10-01' } });
+        const mockEvents: Event[] = [
+            {
+                id: 1,
+                name: 'Test Event',
+                description: 'This is a test event',
+                date: new Date('2023-10-01'),
+                createdById: 1,
+                attendees: [],
+                location: 'Test Location',
+                cycle: 1,
+                createdAt: new Date('2023-10-01'),
+                householdId: 1,
+                updatedAt: new Date('2023-10-01'),
+                repeatCount: 0,
+                parentEventId: null,
+            },
+        ];
+
+        const serializedEvents = JSON.parse(JSON.stringify(mockEvents));
+
+        vi.mocked(prisma.event.findMany).mockResolvedValue(mockEvents);
+        vi.mocked(prisma.event.count).mockResolvedValue(mockEvents.length);
+
+        const response = await GET(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(responseBody.events).toEqual(serializedEvents);
+        expect(responseBody.count).toBe(mockEvents.length);
     });
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+    it('should return 400 if an error occurs', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
+        const req = createMockRequest({ searchParams: {} });
+
+        vi.mocked(prisma.event.findMany).mockRejectedValue(new Error('Database error'));
+
+        const response = await GET(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(responseBody.error).toBe('Invalid request');
+    });
 });
 
-test('POST Event with invalid data should return 400', async () => {
-    const mockInvalidEvent = {
-        name: 'Test Event',
-        description: 'Test Description',
-        date: 'invalid_date', // Not a valid date
-        attendees: [1, 2],
-        householdId: 1,
-        createdById: 1,
+describe('Event POST API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const { searchParams = {}, body = {} } = options;
+
+        const url = new URL('http://localhost:3000/api/event/create');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body)
+        } as unknown as Request;
     };
 
-    const req = new Request('http://localhost/api/event', {
-        method: 'POST',
-        body: JSON.stringify(mockInvalidEvent),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+    it('should return 401 if user is not authenticated', async () => {
+        vi.mocked(getServerSession).mockResolvedValue(null);
+
+        const req = createMockRequest({ searchParams: {} });
+        const response = await POST(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(401);
+        expect(responseBody).toEqual({ message: 'You must be logged in to create events' });
     });
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+    it('should return 401 if user is not part of a household', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1' },
+        } as MockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
-});
+        const req = createMockRequest({ searchParams: {} });
+        const response = await POST(req);
+        const responseBody = await response.json();
 
-test('GET Event with valid userId should return events', async () => {
-    const mockEvents = [
-        {
+        expect(response.status).toBe(401);
+        expect(responseBody).toEqual({ message: 'You must be a part of a household to create events' });
+    })
+
+    it('should create an event for the authenticated user', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: {id: '1', householdId: '1'},
+        } as MockSession);
+
+        const req = createMockRequest({
+            body: {
+                name: 'Test Event',
+                description: 'This is a test event',
+                date: new Date('2023-10-01'),
+                location: 'Test Location',
+                cycle: 1,
+                repeatCount: 0,
+                parentEventId: null,
+                attendees: [1],
+            }
+        });
+
+        const mockEvent = {
             id: 1,
-            name: 'Test Event 1',
-            description: 'Test Description 1',
-            date: '2023-10-01',
-            householdId: 1,
+            name: 'Test Event',
+            description: 'This is a test event',
+            date: new Date('2023-10-01'),
             createdById: 1,
-        },
-        {
-            id: 2,
-            name: 'Test Event 2',
-            description: 'Test Description 2',
-            date: '2023-10-02',
+            attendees: [1],
+            location: 'Test Location',
+            cycle: 1,
+            createdAt: new Date('2023-10-01'),
             householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            repeatCount: 0,
+            parentEventId: null,
+        };
+
+        const mockAttendees = [
+            {
+                userId: 1,
+                eventId: 1,
+                user: {
+                    id: 1,
+                    username: 'testuser',
+                },
+            },
+        ];
+
+        const serializedEvent = JSON.parse(JSON.stringify(mockEvent));
+
+        vi.mocked(prisma.event.create).mockResolvedValue(mockEvent);
+        vi.mocked(prisma.eventAttendee.createMany).mockResolvedValue({
+            count: mockAttendees.length,
+        });
+
+        const response = await POST(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(201);
+        expect(responseBody).toEqual(serializedEvent);
+    });
+
+    it('should return 400 if an error occurs', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
+
+        const req = createMockRequest({ searchParams: {} });
+
+        vi.mocked(prisma.event.create).mockRejectedValue(new Error('Database error'));
+
+        const response = await POST(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(responseBody.error).toBe('Invalid request');
+    });
+});
+
+describe('Event DELETE API', () => {
+    it('should return 401 if user is not authenticated', async () => {
+        vi.mocked(getServerSession).mockResolvedValue(null);
+
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+        });
+
+        const response = await DELETE(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(401);
+        expect(responseBody).toEqual({ message: 'You must be logged in to delete events' });
+    });
+
+    it('should return 401 if user is not part of a household', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1' },
+        } as MockSession);
+
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+        });
+
+        const response = await DELETE(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(401);
+        expect(responseBody).toEqual({ message: 'You must be a part of a household to delete events' });
+    });
+
+    it('should return 400 if eventId is missing', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
+
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({}),
+        });
+
+        const response = await DELETE(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(responseBody).toEqual({ error: 'Missing eventId parameter' });
+    });
+
+    it('should return 400 if eventId is invalid', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
+
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({ eventId: 'invalid' }),
+        });
+
+        const response = await DELETE(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(responseBody).toEqual({ error: 'Invalid eventId parameter' });
+    });
+
+    it('should return 404 if event is not found', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
+
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({ eventId: 1 }),
+        });
+
+        vi.mocked(prisma.event.findUnique).mockResolvedValue(null);
+
+        const response = await DELETE(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(responseBody).toEqual({ error: 'Event not found' });
+    });
+
+    it('should return 403 if user is not authorized to delete the event', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
+
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({ eventId: 1 }),
+        });
+
+        const mockEvent = {
+            id: 1,
+            name: 'Test Event',
+            description: 'This is a test event',
+            date: new Date('2023-10-01'),
+            createdById: 2,
+            attendees: [],
+            location: 'Test Location',
+            cycle: 1,
+            createdAt: new Date('2023-10-01'),
+            householdId: 2,
+            updatedAt: new Date('2023-10-01'),
+            repeatCount: 0,
+            parentEventId: null,
+        };
+
+        vi.mocked(prisma.event.findUnique).mockResolvedValue(mockEvent);
+
+        const response = await DELETE(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(responseBody).toEqual({ error: 'Not authorized to delete this event' });
+    });
+
+    it('should delete an event for the authenticated user', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
+
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({ eventId: 1 }),
+        });
+
+        const mockEvent = {
+            id: 1,
+            name: 'Test Event',
+            description: 'This is a test event',
+            date: new Date('2023-10-01'),
             createdById: 1,
-        },
-    ];
+            attendees: [],
+            location: 'Test Location',
+            cycle: 1,
+            createdAt: new Date('2023-10-01'),
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            repeatCount: 0,
+            parentEventId: null,
+        };
 
-    const req = new Request('http://localhost/api/event?userId=1', {
-        method: 'GET',
+        vi.mocked(prisma.event.findUnique).mockResolvedValue(mockEvent);
+        vi.mocked(prisma.event.delete).mockResolvedValue(mockEvent);
+
+        const response = await DELETE(req);
+
+        expect(response.status).toBe(204);
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.event.findMany.mockResolvedValue(mockEvents);
+    it('should return 500 if an error occurs', async () => {
+        vi.mocked(getServerSession).mockResolvedValue({
+            user: { id: '1', householdId: '1' },
+        } as MockSession);
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+        const req = new Request('http://localhost:3000/api/event/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({ eventId: 1 }),
+        });
 
-    expect(response.status).toBe(200);
-    expect(data).toStrictEqual(mockEvents);
-});
+        vi.mocked(prisma.event.findUnique).mockRejectedValue(new Error('Database error'));
 
-test('GET Event with missing userId should return 400', async () => {
-    const req = new Request('http://localhost/api/event', {
-        method: 'GET',
+        const response = await DELETE(req);
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(responseBody.error).toBe('Server error');
     });
-
-    const response = await GET(req as Request);
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Missing userId parameter' });
-});
-
-test('GET Event with invalid userId should return 400', async () => {
-    const req = new Request('http://localhost/api/event?userId=invalid', {
-        method: 'GET',
-    });
-
-    const response = await GET(req as Request);
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid userId parameter' });
-});
-
-test('GET Event rejected by database should return 400', async () => {
-    const req = new Request('http://localhost/api/event?userId=1', {
-        method: 'GET',
-    });
-
-    prisma.event.findMany.mockRejectedValue(new Error('Database error'));
-
-    const response = await GET(req as Request);
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
-});
-
-test('DELETE Event with valid eventId should return 204', async () => {
-    const req = new Request('http://localhost/api/event?eventId=1', {
-        method: 'DELETE',
-    });
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.event.delete.mockResolvedValue({});
-
-    const response = await DELETE(req as Request);
-
-    expect(response.status).toBe(204);
-});
-
-test('DELETE Event with missing eventId should return 400', async () => {
-    const req = new Request('http://localhost/api/event', {
-        method: 'DELETE',
-    });
-
-    const response = await DELETE(req as Request);
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Missing eventId parameter' });
-});
-
-test('DELETE Event with invalid eventId should return 400', async () => {
-    const req = new Request('http://localhost/api/event?eventId=invalid', {
-        method: 'DELETE',
-    });
-
-    const response = await DELETE(req as Request);
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid eventId parameter' });
 });


### PR DESCRIPTION
otestowalem swoje api gng

This pull request introduces several updates across chore and event APIs to improve error handling, enforce household membership checks, and standardize request payloads. Additionally, it includes minor UI adjustments in component error messages and API request formats.

### API Improvements

* Updated error responses to return "Internal Server Error" (status 500) instead of "Invalid request" (status 400) across various endpoints for better alignment with error semantics:
  - `chore/create`, `chore/delete`, `chore/done`, `chore/todo`, `chores/done/get`, `chores/todo/get` [[1]](diffhunk://#diff-ccc75dc69ee3337ac4945e7d6a9b87c70a04c1c42c2a5b3a47db7d3553c3598dL92-R92) [[2]](diffhunk://#diff-9bdbebd244a54cf632d0a882b50f705966ee0c3a0ef202c93e2e34849169bba4L34-R38) [[3]](diffhunk://#diff-22f05d4c9ab12e6c7b0bc295f7e2fefbeee43750a0d6e7932a7df0fabf26ebd3L40-R44) [[4]](diffhunk://#diff-8aec0698bfd830031122bf7ec48b8af3ab767bde09642b8a8150959addbbcd1eL38-R42) [[5]](diffhunk://#diff-85c97527acec057dac9bb79cdbb8b2ff7f95c8f614cf061505f2f1c2c26b02d0L58-R58) [[6]](diffhunk://#diff-3534077c893057fbf3ae68ccd3c8d62a247af76963ad8e4c2c87aef3b697eee1L58-R58)
  - `event/create`, `event/delete`, `events/get` [[1]](diffhunk://#diff-524f471b0db5c7c3c2488c97d8968078c9069397d37aad2c7e9490e78ae712b0L119-R119) [[2]](diffhunk://#diff-f62dffbbbc8186b258b13bfe60a734ac89a835eb191249cb82d00eb6cdb005c2L46-R50) [[3]](diffhunk://#diff-412f4839ad201fa65782b99fb2c3eb4e9f4a6899dd2f2ad2ecb0f22640854850L53-R57)

* Added household membership validation to ensure users belong to a household before performing actions:
  - `chore/delete`, `chore/done`, `chore/todo` [[1]](diffhunk://#diff-9bdbebd244a54cf632d0a882b50f705966ee0c3a0ef202c93e2e34849169bba4R14-R17) [[2]](diffhunk://#diff-22f05d4c9ab12e6c7b0bc295f7e2fefbeee43750a0d6e7932a7df0fabf26ebd3R14-R17) [[3]](diffhunk://#diff-8aec0698bfd830031122bf7ec48b8af3ab767bde09642b8a8150959addbbcd1eR14-R17)
  - `event/delete`, `events/get` [[1]](diffhunk://#diff-f62dffbbbc8186b258b13bfe60a734ac89a835eb191249cb82d00eb6cdb005c2R14-R21) [[2]](diffhunk://#diff-412f4839ad201fa65782b99fb2c3eb4e9f4a6899dd2f2ad2ecb0f22640854850R16-R19)

* Refactored `event/delete` to accept `eventId` in the request body instead of query parameters, aligning with RESTful conventions [[1]](diffhunk://#diff-f62dffbbbc8186b258b13bfe60a734ac89a835eb191249cb82d00eb6cdb005c2R14-R21) [[2]](diffhunk://#diff-64578b5ea540333abf4dc91e6f17e5176e0dd568dfa2f8f71d6043e71ad6997eL168-R173).

### Event Creation Enhancements

* Made the `description` field mandatory for event creation and removed fallback logic for empty descriptions in `event/create` [[1]](diffhunk://#diff-524f471b0db5c7c3c2488c97d8968078c9069397d37aad2c7e9490e78ae712b0L12-R25) [[2]](diffhunk://#diff-524f471b0db5c7c3c2488c97d8968078c9069397d37aad2c7e9490e78ae712b0L36-R36) [[3]](diffhunk://#diff-524f471b0db5c7c3c2488c97d8968078c9069397d37aad2c7e9490e78ae712b0L69-R69).

### UI Adjustments

* Updated error messages in `ChoreDoneCard` to reflect the new terminology ("todo" instead of "undone") for marking chores as incomplete.
* Adjusted the API request format in `EventCard` to include headers and a JSON body for deleting events.