### PR TITLE
Bills n Shopping List API Unit Tests

### DIFF
--- a/forttask/src/app/api/bill/route.ts
+++ b/forttask/src/app/api/bill/route.ts
@@ -53,7 +53,7 @@ export async function POST(req: Request) {
         return NextResponse.json(newBill, { status: 201 });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }
 
@@ -109,7 +109,7 @@ export async function GET(req: Request) {
         return NextResponse.json(bills, { status: 200 });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }
 
@@ -158,6 +158,6 @@ export async function DELETE(req: Request) {
         return NextResponse.json({ message: 'Bill deleted successfully' }, { status: 200 });
     } catch (error) {
         console.error('Error deleting bill:', error);
-        return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+        return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/forttask/src/app/api/bill/totalNumber/route.ts
+++ b/forttask/src/app/api/bill/totalNumber/route.ts
@@ -42,6 +42,6 @@ export async function GET(req: Request) {
         return NextResponse.json({ count }, { status: 200 });
     } catch (error) {
         console.error(error);
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/forttask/src/app/api/shoppingList/route.ts
+++ b/forttask/src/app/api/shoppingList/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
         const session = await getServerSession(authOptions);
 
         if (!session || !session.user?.id) {
-            return NextResponse.json({ message: 'You must be logged in to join a household' }, { status: 401 });
+            return NextResponse.json({ message: 'You must be logged in to create a shopping item' }, { status: 401 });
         }
 
         const userId = parseInt(session.user.id);

--- a/forttask/src/app/api/shoppingList/totalNumber/route.ts
+++ b/forttask/src/app/api/shoppingList/totalNumber/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
 
         if (!session || !session.user?.id) {
             return NextResponse.json(
-                { message: 'You must be logged in to view the shopping list count' },
+                { message: 'You must be logged in to view shopping list count' },
                 { status: 401 },
             );
         }
@@ -27,7 +27,7 @@ export async function GET(req: Request) {
 
         if (!user.householdId) {
             return NextResponse.json(
-                { message: 'You must be a member of a household to view the shopping list count' },
+                { message: 'You must be a member of a household to view shopping list count' },
                 { status: 403 },
             );
         }

--- a/forttask/test/bill.test.ts
+++ b/forttask/test/bill.test.ts
@@ -1,183 +1,1050 @@
-import { expect, test, vi } from 'vitest';
-import { POST, GET, DELETE } from '../src/app/api/bill/route';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST, DELETE } from '../src/app/api/bill/route';
+import { GET as GET_Details } from '../src/app/api/bill/details/route';
+import { GET as GET_TotalNumber } from '../src/app/api/bill/totalNumber/route';
+import { PUT } from '../src/app/api/bill/paidToggle/route';
 import prisma from '../libs/__mocks__/prisma';
+import { getServerSession } from 'next-auth/next';
+import { Prisma } from '@prisma/client';
 
 vi.mock('../libs/prisma');
+vi.mock('next-auth/next', () => ({
+    getServerSession: vi.fn(),
+}));
 
-test('POST Bill with correct data should return new Bill and status 201', async () => {
-    const mockBill = {
-        name: 'Test Bill',
-        amount: 100,
-        dueDate: '2023-10-01',
-        description: 'Test Description',
-        householdId: 1,
-        createdById: 1,
+type MockSession = {
+    user?: {
+        id?: string;
+        householdId?: string;
+    };
+    expires?: string;
+};
+
+type MockRequestOptions = {
+    searchParams?: Record<string, string>;
+    body?: Record<string, unknown>;
+};
+
+describe('Bill GET API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const { searchParams = {}, body = {} } = options;
+
+        const url = new URL('http://localhost:3000/api/bill');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
     };
 
-    const req = new Request('http://localhost/api/bill', {
-        method: 'POST',
-        body: JSON.stringify(mockBill),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({});
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({ message: 'You must be logged in to get the bills' });
     });
 
-    const mockResponse = { ...mockBill, id: 1 };
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.bill.create.mockResolvedValue(mockResponse);
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: { id: '1' },
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
 
-    expect(response.status).toBe(201);
-    expect(data).toStrictEqual(mockResponse);
-});
+        const request = createMockRequest({});
 
-test('POST Bill with missing fields should return 400', async () => {
-    const req = new Request('http://localhost/api/bill', {
-        method: 'POST',
-        body: JSON.stringify({}),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+        const response = await GET(request);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({ message: 'User not found' });
+    })
+
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: { id: '1' },
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({});
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({ message: 'You must be a member of a household to get the bills' });
     });
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+    it('should return 200 and the list of bills', async () => {
+        const mockSession: MockSession = {
+            user: { id: '1', householdId: '1' },
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
+        const mockBills = [
+            {
+                id: 1,
+                name: 'Bill 1',
+                amount: Prisma.Decimal(100),
+                cycle: 1,
+                dueDate: new Date('2023-10-01'),
+                createdById: 1,
+                createdAt: new Date('2023-10-01'),
+                updatedAt: new Date('2023-10-01'),
+                description: 'Test bill 1',
+                householdId: 1,
+                paidById: null,
+            },
+            {
+                id: 2,
+                name: 'Bill 2',
+                amount: Prisma.Decimal(200),
+                cycle: 1,
+                dueDate: new Date('2023-11-01'),
+                createdById: 1,
+                createdAt: new Date('2023-10-01'),
+                updatedAt: new Date('2023-10-01'),
+                description: 'Test bill 2',
+                householdId: 1,
+                paidById: null,
+            },
+        ];
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findMany).mockResolvedValueOnce(mockBills);
+
+        const serializedBills = JSON.parse(JSON.stringify(mockBills));
+
+        const request = createMockRequest({});
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual(serializedBills);
+    });
+
+    it('should return 500 if an error occurs', async () => {
+        const mockSession: MockSession = {
+            user: { id: '1', householdId: '1' },
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.bill.findMany).mockRejectedValueOnce(new Error('Database error'));
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const request = createMockRequest({});
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({ error: 'Internal Server Error' });
+    });
 });
 
-test('POST Bill with invalid data should return 400', async () => {
-    const mockInvalidBill = {
-        name: 'Test Bill',
-        amount: 'invalid_amount', // Not number
-        dueDate: '2023-10-01',
-        description: 'Test Description',
-        householdId: 1,
-        createdById: 1,
+describe('Bill POST API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}, body = {}} = options;
+
+        const url = new URL('http://localhost:3000/api/bill');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
     };
 
-    const req = new Request('http://localhost/api/bill', {
-        method: 'POST',
-        body: JSON.stringify(mockInvalidBill),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({});
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to create a bill'});
     });
 
-    prisma.bill.create.mockRejectedValue(new Error('Invalid data'));
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
+        const request = createMockRequest({});
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
+    });
+
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({});
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to create a bill'});
+    });
+
+    it('should return 201 and create a new bill', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const body = {
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            description: 'Test bill',
+        }
+
+        const mockBill = {
+            id: 1,
+            ...body,
+            createdById: 1,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            householdId: 1,
+            paidById: null,
+        };
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.create).mockResolvedValueOnce(mockBill);
+
+        const serializedBill = JSON.parse(JSON.stringify(mockBill));
+
+        const request = createMockRequest({body});
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(201);
+        const data = await response.json();
+        expect(data).toEqual(serializedBill);
+    });
+
+    it('should return 500 if an error occurs', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const body = {
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            description: 'Test bill',
+        }
+
+        vi.mocked(prisma.bill.create).mockRejectedValueOnce(new Error('Database error'));
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const request = createMockRequest({body});
+
+        const response = await POST(request);
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({error: 'Internal Server Error'});
+    });
 });
 
-test('GET Bill with correct householdId should return all bills for household and status 200', async () => {
-    const mockBill = {
-        name: 'Test Bill',
-        amount: 100,
-        dueDate: '2023-10-01',
-        description: 'Test Description',
-        householdId: 1,
-        createdById: 1,
+describe('Bill DELETE API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}, body = {}} = options;
+
+        const url = new URL('http://localhost:3000/api/bill');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
     };
 
-    const req = new Request('http://localhost/api/bill?householdId=1', {
-        method: 'GET',
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({});
+
+        const response = await DELETE(request);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to delete a bill'});
     });
 
-    const mockResponse = [mockBill];
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.bill.findMany.mockResolvedValue(mockResponse);
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
 
-    expect(response.status).toBe(200);
-    expect(data).toStrictEqual(mockResponse);
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 2,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 1,
+            paidById: null,
+        });
+
+        const request = createMockRequest({ searchParams: { id: '1' } });
+
+        const response = await DELETE(request);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
+    });
+
+    it('should return 403 if user is not authorized to delete', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 2,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 1,
+            paidById: null,
+        });
+
+        const request = createMockRequest({ searchParams: { id: '1' } });
+
+        const response = await DELETE(request);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You are not authorized to delete this bill'});
+    });
+
+    it('should return 404 if bill is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({ searchParams: { id: '2' } });
+
+        const response = await DELETE(request);
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Bill not found'});
+    });
+
+    it('should return 400 if bill id is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 2,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 1,
+            paidById: null,
+        });
+
+        const request = createMockRequest({ searchParams: { id: 'invalid' } });
+
+        const response = await DELETE(request);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid bill ID'});
+    });
+
+    it('should return 200 and delete the bill', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const mockBill = {
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 1,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 1,
+            paidById: null,
+        };
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce(mockBill);
+        vi.mocked(prisma.bill.delete).mockResolvedValueOnce(mockBill);
+
+        const request = createMockRequest({ searchParams: { id: '1' } });
+
+        const response = await DELETE(request);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Bill deleted successfully'});
+    });
+
+    it('should return 500 if an error occurs', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 1,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 1,
+            paidById: null,
+        });
+
+        vi.mocked(prisma.bill.delete).mockRejectedValueOnce(new Error('Database error'));
+
+        const request = createMockRequest({ searchParams: { id: '1' } });
+
+        const response = await DELETE(request);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal Server Error'});
+    });
 });
 
-test('GET Bill with missing householdId should return 400', async () => {
-    const req = new Request('http://localhost/api/bill', {
-        method: 'GET',
+describe('Bill GET Details API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}, body = {}} = options;
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Missing householdId parameter' });
+        const url = new URL('http://localhost:3000/api/bill/details');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
+    };
+
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({});
+
+        const response = await GET_Details(request);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({error: 'Unauthorized'});
+    });
+
+    it('should return 400 if id is not provided', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({});
+
+        const response = await GET_Details(request);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({error: 'ID is required'});
+    });
+
+    it('should return 404 if bill is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({ searchParams: { id: '1' } });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce(null);
+
+        const response = await GET_Details(request);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({error: 'Bill not found'});
+    });
+
+    it('should return 200 and bill details', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const mockBillDetails = {
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 1,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 1,
+            paidById: null,
+        };
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce(mockBillDetails);
+
+        const serializedBillDetails = JSON.parse(JSON.stringify(mockBillDetails));
+
+        const request = createMockRequest({ searchParams: { id: '1' } });
+
+        const response = await GET_Details(request);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual(serializedBillDetails);
+    });
+
+    it('should return 500 if an error occurs', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.bill.findUnique).mockRejectedValueOnce(new Error('Database error'));
+
+        const request = createMockRequest({ searchParams: { id: '1' } });
+
+        const response = await GET_Details(request);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({error: 'Internal Server Error'});
+    });
 });
 
-test('GET Bill with invalid householdId should return 400', async () => {
-    const req = new Request('http://localhost/api/bill?householdId=invalid', {
-        method: 'GET',
+describe('Bill GET Total Number API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}, body = {}} = options;
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid householdId parameter' });
+        const url = new URL('http://localhost:3000/api/bill/totalNumber');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
+    };
+
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({});
+
+        const response = await GET_TotalNumber(request);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to get the total number of bills'});
+    });
+
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({});
+
+        const response = await GET_TotalNumber(request);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
+    });
+
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({});
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const response = await GET_TotalNumber(request);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to get the total number of bills'});
+    });
+
+    it('should return 200 and the total number of bills', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const mockCount = 5;
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.count).mockResolvedValueOnce(mockCount);
+
+        const request = createMockRequest({});
+
+        const response = await GET_TotalNumber(request);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual({count: mockCount});
+    });
+
+    it('should return 500 if an error occurs', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.bill.count).mockRejectedValueOnce(new Error('Database error'));
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const request = createMockRequest({});
+
+        const response = await GET_TotalNumber(request);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({error: 'Internal Server Error'});
+    });
 });
 
-test('GET Bill rejected by database should return 400', async () => {
-    const req = new Request('http://localhost/api/bill?householdId=1', {
-        method: 'GET',
+describe('Bill PUT Paid Toggle API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    prisma.bill.findMany.mockRejectedValue(new Error('Database error'));
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}, body = {}} = options;
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+        const url = new URL('http://localhost:3000/api/bill/paidToggle');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
-});
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
+    };
 
-test('DELETE Bill with correct billId should return 204', async () => {
-    const req = new Request('http://localhost/api/bill?billId=1', {
-        method: 'DELETE',
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const request = createMockRequest({});
+
+        const response = await PUT(request);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to mark items as bought'});
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.bill.delete.mockResolvedValue({});
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    const response = await DELETE(req as Request);
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
 
-    expect(response.status).toBe(204);
-});
+        const request = createMockRequest({});
 
-test('DELETE Bill with missing billId should return 400', async () => {
-    const req = new Request('http://localhost/api/bill', {
-        method: 'DELETE',
+        const response = await PUT(request);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
     });
 
-    const response = await DELETE(req as Request);
-    const data = await response.json();
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Missing billId parameter' });
-});
+        const request = createMockRequest({});
 
-test('DELETE Bill with invalid billId should return 400', async () => {
-    const req = new Request('http://localhost/api/bill?billId=invalid', {
-        method: 'DELETE',
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const response = await PUT(request);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to mark items as bought'});
     });
 
-    const response = await DELETE(req as Request);
-    const data = await response.json();
+    it('should return 400 if request body is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid billId parameter' });
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const request = createMockRequest({body: {}});
+
+        const response = await PUT(request);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid request'});
+    });
+
+    it('should return 404 if bill is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({body: {id: 1, paid: true}});
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce(null);
+
+        const response = await PUT(request);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Bill not found'});
+    });
+
+    it('should return 403 if user does not have permission to mark the bill as paid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({body: {id: 1, paid: true}});
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 2,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 2,
+            paidById: null,
+        });
+
+        const response = await PUT(request);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You do not have permission to mark this bill as paid'});
+    });
+
+    it('should return 200 and update the bill as paid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1', householdId: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        const request = createMockRequest({body: {id: 1, paid: true}});
+
+        const mockBill = {
+            id: 1,
+            name: 'Test Bill',
+            amount: Prisma.Decimal(100),
+            cycle: 1,
+            dueDate: new Date('2023-10-01'),
+            createdById: 1,
+            createdAt: new Date('2023-10-01'),
+            updatedAt: new Date('2023-10-01'),
+            description: 'Test bill',
+            householdId: 1,
+            paidById: null,
+        };
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.bill.findUnique).mockResolvedValueOnce(mockBill);
+        vi.mocked(prisma.bill.update).mockResolvedValueOnce({
+            ...mockBill,
+            paidById: 1,
+            updatedAt: new Date('2023-10-01'),
+        });
+
+        const serializedBill = JSON.parse(JSON.stringify({
+            ...mockBill,
+            paidById: 1,
+            updatedAt: new Date('2023-10-01'),
+        }));
+
+        const response = await PUT(request);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Bill updated successfully', bill: serializedBill});
+    });
 });

--- a/forttask/test/shopping.test.ts
+++ b/forttask/test/shopping.test.ts
@@ -1,175 +1,1529 @@
-import { expect, test, vi } from 'vitest';
-import { POST, GET, DELETE } from '../src/app/api/shopping/route';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST, DELETE } from '../src/app/api/shoppingList/route';
+import { PUT as PUT_Bought } from '../src/app/api/shoppingList/bought/route';
+import { GET as GET_Count } from '../src/app/api/shoppingList/totalNumber/route';
+import { GET as GET_Details } from '../src/app/api/shoppingList/details/route';
+import { PUT as PUT_Unbought } from '../src/app/api/shoppingList/unbought/route';
 import prisma from '../libs/__mocks__/prisma';
+import { getServerSession } from 'next-auth/next';
 
 vi.mock('../libs/prisma');
+vi.mock('next-auth/next', () => ({
+    getServerSession: vi.fn(),
+}));
 
-test('POST Shopping with correct data should return new Shopping and status 201', async () => {
-    const mockShopping = {
-        name: 'Test Shopping',
-        description: 'Test Description',
-        quantity: 1,
-        householdId: 1,
-        createdById: 1,
+type MockSession = {
+    user?: {
+        id?: string;
+        householdId?: string;
+    };
+    expires?: string;
+};
+
+type MockRequestOptions = {
+    searchParams?: Record<string, string>;
+    body?: Record<string, unknown>;
+};
+
+describe('Shopping List GET API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}, body = {}} = options;
+
+        const url = new URL('http://localhost:3000/api/shoppingList');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
     };
 
-    const req = new Request('http://localhost/api/shopping', {
-        method: 'POST',
-        body: JSON.stringify(mockShopping),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await GET(req);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to view the shopping list'});
     });
 
-    const mockResponse = { ...mockShopping, id: 1 };
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.shoppingItem.create.mockResolvedValue(mockResponse);
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
 
-    expect(response.status).toBe(201);
-    expect(data).toStrictEqual(mockResponse);
-});
+        const req = createMockRequest({});
 
-test('POST Shopping with missing fields should return 400', async () => {
-    const req = new Request('http://localhost/api/shopping', {
-        method: 'POST',
-        body: JSON.stringify({}),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+        const response = await GET(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
     });
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const req = createMockRequest({});
+
+        const response = await GET(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to view the shopping list'});
+    });
+
+    it('should return 400 if skip parameter is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            searchParams: {skip: '-1', limit: '10'},
+        });
+
+        const response = await GET(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid skip parameter'});
+    });
+
+    it('should return 400 if limit parameter is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            searchParams: {skip: '0', limit: '0'},
+        });
+
+        const response = await GET(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid limit parameter'});
+    });
+
+    it('should return 200 and the shopping list', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const mockShoppingItems = [
+            {
+                id: 1,
+                name: 'Milk',
+                quantity: 2,
+                createdAt: new Date('2023-10-01'),
+                createdById: 1,
+                householdId: 1,
+                updatedAt: new Date('2023-10-01'),
+                cost: 3.5,
+                boughtById: null,
+            },
+            {
+                id: 2,
+                name: 'Bread',
+                quantity: 1,
+                createdAt: new Date('2023-10-02'),
+                createdById: 1,
+                householdId: 1,
+                updatedAt: new Date('2023-10-02'),
+                cost: 1.5,
+                boughtById: null,
+            },
+        ];
+
+        vi.mocked(prisma.shoppingItem.findMany).mockResolvedValueOnce(mockShoppingItems);
+
+        const serializedShoppingItems = JSON.parse(JSON.stringify(mockShoppingItems));
+
+        const req = createMockRequest({
+            searchParams: {skip: '0', limit: '10'},
+        });
+
+        const response = await GET(req);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual(serializedShoppingItems);
+    });
+
+    it('should return 500 if there is an internal server error', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findMany).mockRejectedValueOnce(new Error('Internal server error'));
+
+        const req = createMockRequest({
+            searchParams: {skip: '0', limit: '10'},
+        });
+
+        const response = await GET(req);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal server error'});
+    });
 });
 
-test('POST Shopping with invalid data should return 400', async () => {
-    const mockInvalidShopping = {
-        name: 'Test Shopping',
-        description: 'Test Description',
-        quantity: 'invalid_quantity', // Not number
-        createdAt: '2023-09-01',
-        householdId: 1,
-        createdById: 1,
+describe('Shopping List POST API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {body = {}} = options;
+
+        return {
+            url: 'http://localhost:3000/api/shoppingList',
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
     };
 
-    const req = new Request('http://localhost/api/shopping', {
-        method: 'POST',
-        body: JSON.stringify(mockInvalidShopping),
-        headers: {
-            'Content-Type': 'application/json',
-        },
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await POST(req);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to create a shopping item'});
     });
 
-    const response = await POST(req as Request);
-    const data = await response.json();
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({ body: { name: 'Milk', cost: 2 }});
+
+        const response = await POST(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
+    });
+
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const req = createMockRequest({ body: { name: 'Milk', cost: 2 } });
+
+        const response = await POST(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to add items'});
+    });
+
+    it('should return 500 if there is an internal server error', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.create).mockRejectedValueOnce(new Error('Internal server error'));
+
+        const req = createMockRequest({
+            body: {name: 'Milk', cost: 2},
+        });
+
+        const response = await POST(req);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal server error'});
+    });
+
+    it('should return 201 and the created shopping item', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const mockShoppingItem = {
+            id: 1,
+            name: 'Milk',
+            quantity: 2,
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        };
+
+        vi.mocked(prisma.shoppingItem.create).mockResolvedValueOnce(mockShoppingItem);
+
+        const serializedShoppingItem = JSON.parse(JSON.stringify(mockShoppingItem));
+
+        const req = createMockRequest({
+            body: {name: 'Milk', cost: 2},
+        });
+
+        const response = await POST(req);
+
+        expect(response.status).toBe(201);
+        const data = await response.json();
+        expect(data).toEqual(serializedShoppingItem);
+    });
+
+    it('should return 400 if name is empty', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            body: {name: '', quantity: 2},
+        });
+
+        const response = await POST(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Name is required'});
+    });
+
+    it('should return 400 if cost is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            body: {name: 'Milk', cost: -1},
+        });
+
+        const response = await POST(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Cost must be a positive number'});
+    });
 });
 
-test('GET Shopping with valid householdId should return list of Shopping', async () => {
-    const mockShoppingList = [
-        { id: 1, name: 'Test Shopping 1', householdId: 1 },
-        { id: 2, name: 'Test Shopping 2', householdId: 1 },
-    ];
-
-    const req = new Request('http://localhost/api/shopping?householdId=1', {
-        method: 'GET',
+describe('Shopping List DELETE API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.shoppingItem.findMany.mockResolvedValue(mockShoppingList);
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}} = options;
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+        const url = new URL('http://localhost:3000/api/shoppingList');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
 
-    expect(response.status).toBe(200);
-    expect(data).toStrictEqual(mockShoppingList);
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve({}),
+        } as unknown as Request;
+    };
+
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await DELETE(req);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to delete an item'});
+    });
+
+    it('should return 400 if item ID is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            searchParams: {id: 'invalid'},
+        });
+
+        const response = await DELETE(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid item ID'});
+    });
+
+    it('should return 404 if item is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await DELETE(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Item not found'});
+    });
+
+    it('should return 403 if user is not authorized to delete the item', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 2,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await DELETE(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You are not authorized to delete this item'});
+    });
+
+    it('should return 500 if there is an internal server error', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        vi.mocked(prisma.shoppingItem.delete).mockRejectedValueOnce(new Error('Internal server error'));
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await DELETE(req);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal server error'});
+    });
+
+    it('should return 200 if item is deleted successfully', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        vi.mocked(prisma.shoppingItem.delete).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await DELETE(req);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Item deleted successfully'});
+    });
 });
 
-test('GET Shopping with missing householdId should return 400', async () => {
-    const req = new Request('http://localhost/api/shopping', {
-        method: 'GET',
+describe('Shopping List Bought API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {body = {}} = options;
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Missing householdId parameter' });
+        return {
+            url: 'http://localhost:3000/api/shoppingList/bought',
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
+    };
+
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to mark items as bought'});
+    });
+
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({ body: { id: 1 } });
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
+    });
+
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const req = createMockRequest({ body: { id: 1 } });
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to mark items as bought'});
+    });
+
+    it('should return 400 if item ID is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            body: {id: 'invalid'},
+        });
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid item ID'});
+    });
+
+    it('should return 404 if item is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Item not found'});
+    });
+
+    it('should return 403 if user is not authorized to mark the item as bought', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 2,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 2,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You do not have permission to mark this item as bought'});
+    });
+
+    it('should return 500 if there is an internal server error', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        vi.mocked(prisma.shoppingItem.update).mockRejectedValueOnce(new Error('Internal server error'));
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal server error'});
+    });
+
+    it('should return 200 and the updated item if marked as bought successfully', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        const updatedItem = {
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: 1,
+        };
+
+        vi.mocked(prisma.shoppingItem.update).mockResolvedValueOnce(updatedItem);
+
+        const serializedUpdatedItem = JSON.parse(JSON.stringify(updatedItem));
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Bought(req);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual(serializedUpdatedItem);
+    });
 });
 
-test('GET Shopping with invalid householdId should return 400', async () => {
-    const req = new Request('http://localhost/api/shopping?householdId=invalid', {
-        method: 'GET',
+describe('Shopping List Unbought API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {body = {}} = options;
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid householdId parameter' });
+        return {
+            url: 'http://localhost:3000/api/shoppingList/unbought',
+            json: () => Promise.resolve(body),
+        } as unknown as Request;
+    };
+
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to mark items as unbought'});
+    });
+
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({ body: { id: 1 } });
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
+    });
+
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const req = createMockRequest({ body: { id: 1 } });
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to mark items as unbought'});
+    });
+
+    it('should return 400 if item ID is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            body: {id: 'invalid'},
+        });
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid item ID'});
+    });
+
+    it('should return 404 if item is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Item not found'});
+    });
+
+    it('should return 403 if user is not authorized to mark the item as unbought', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 2,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 2,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: 1,
+        });
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You do not have permission to mark this item as unbought'});
+    });
+
+    it('should return 500 if there is an internal server error', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.update).mockRejectedValueOnce(new Error('Internal server error'));
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal server error'});
+    });
+
+    it('should return 200 if item is marked as unbought successfully', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.update).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        const req = createMockRequest({
+            body: {id: 1},
+        });
+
+        const response = await PUT_Unbought(req);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Item marked as unbought successfully'});
+    });
 });
 
-test('GET Shopping rejected by database should return 400', async () => {
-    const req = new Request('http://localhost/api/shopping?householdId=1', {
-        method: 'GET',
+describe('Shopping List TotalNumber API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    prisma.shoppingItem.findMany.mockRejectedValue(new Error('Database error'));
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}} = options;
 
-    const response = await GET(req as Request);
-    const data = await response.json();
+        const url = new URL('http://localhost:3000/api/shoppingList/totalNumber');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid request' });
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve({})
+        } as unknown as Request;
+    };
+
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await GET_Count(req);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to view shopping list count'});
+    });
+
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await GET_Count(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
+    });
+
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const req = createMockRequest({});
+
+        const response = await GET_Count(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to view shopping list count'});
+    });
+
+    it('should return 500 if there is an internal server error', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.count).mockRejectedValueOnce(new Error('Internal server error'));
+
+        const req = createMockRequest({});
+
+        const response = await GET_Count(req);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal server error'});
+    });
+
+    it('should return 200 and the count of shopping items', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.count).mockResolvedValueOnce(5);
+
+        const req = createMockRequest({});
+
+        const response = await GET_Count(req);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual({count: 5});
+    });
 });
 
-test('DELETE Shopping with valid id should return 204', async () => {
-    const req = new Request('http://localhost/api/shopping?id=1', {
-        method: 'DELETE',
+describe('Shopping List Details API', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    // tajpskript diff
-    prisma.shoppingItem.delete.mockResolvedValue({});
+    const createMockRequest = (options: MockRequestOptions): Request => {
+        const {searchParams = {}} = options;
 
-    const response = await DELETE(req as Request);
+        const url = new URL('http://localhost:3000/api/shoppingList/details');
+        Object.entries(searchParams).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
 
-    expect(response.status).toBe(204);
-});
+        return {
+            url: url.toString(),
+            json: () => Promise.resolve({})
+        } as unknown as Request;
+    };
 
-test('DELETE Shopping with missing id should return 400', async () => {
-    const req = new Request('http://localhost/api/shopping', {
-        method: 'DELETE',
+    it('should return 401 if user is not logged in', async () => {
+        vi.mocked(getServerSession).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({});
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(401);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be logged in to view item details'});
     });
 
-    const response = await DELETE(req as Request);
-    const data = await response.json();
+    it('should return 404 if user is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Missing id parameter' });
-});
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
 
-test('DELETE Shopping with invalid id should return 400', async () => {
-    const req = new Request('http://localhost/api/shopping?id=invalid', {
-        method: 'DELETE',
+        const req = createMockRequest({});
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'User not found'});
     });
 
-    const response = await DELETE(req as Request);
-    const data = await response.json();
+    it('should return 403 if user is not a member of a household', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
 
-    expect(response.status).toBe(400);
-    expect(data).toStrictEqual({ error: 'Invalid id parameter' });
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: null,
+        });
+
+        const req = createMockRequest({});
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You must be a member of a household to view item details'});
+    });
+
+    it('should return 400 if item ID is invalid', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const req = createMockRequest({
+            searchParams: {id: 'invalid'},
+        });
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Invalid item ID'});
+    });
+
+    it('should return 404 if item is not found', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce(null);
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(404);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Item not found'});
+    });
+
+    it('should return 403 if user is not authorized to view the item', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 2,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce({
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 2,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+        });
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(403);
+        const data = await response.json();
+        expect(data).toEqual({message: 'You do not have permission to view this item'});
+    });
+
+    it('should return 500 if there is an internal server error', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockRejectedValueOnce(new Error('Internal server error'));
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({message: 'Internal server error'});
+    });
+
+    it('should return 200 and the item details', async () => {
+        const mockSession: MockSession = {
+            user: {id: '1'},
+        };
+        vi.mocked(getServerSession).mockResolvedValueOnce(mockSession);
+
+        vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+            id: 1,
+            createdAt: new Date('2023-10-01'),
+            username: 'testuser',
+            email: 'test@test.test',
+            passwordHash: 'hashedpassword',
+            profilePictureId: null,
+            householdId: 1,
+        });
+
+        const mockItem = {
+            id: 1,
+            name: 'Milk',
+            createdAt: new Date('2023-10-01'),
+            createdById: 1,
+            householdId: 1,
+            updatedAt: new Date('2023-10-01'),
+            cost: 3.5,
+            boughtById: null,
+            createdBy: {
+                id: 1,
+                username: 'testuser',
+            },
+            boughtBy: null,
+        };
+
+        vi.mocked(prisma.shoppingItem.findUnique).mockResolvedValueOnce(mockItem);
+
+        const serializedItem = JSON.parse(JSON.stringify(mockItem));
+
+        const req = createMockRequest({
+            searchParams: {id: '1'},
+        });
+
+        const response = await GET_Details(req);
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data).toEqual(serializedItem);
+    });
 });


### PR DESCRIPTION
zapdejtowalem testy dla routeow majdana tego typu benc. szybki merge i zabieram sie za workaround paginacji na pageach majdana i co i tyle reszte testow ogarnia emati.

This pull request includes updates to improve error messaging consistency and clarity across several API routes. Key changes involve standardizing error responses and refining user-facing messages to provide more accurate and professional feedback.

### Error Messaging Standardization:
* Updated error responses in `forttask/src/app/api/bill/route.ts` to return `Internal Server Error` with a 500 status code instead of `Invalid request` for `POST`, `GET`, and `DELETE` methods. This ensures uniform error handling for server-side issues. [[1]](diffhunk://#diff-1e02ad39f9e022e4f760f87db84dcd6625835231b9bb4f8083ec7580ceb77099L56-R56) [[2]](diffhunk://#diff-1e02ad39f9e022e4f760f87db84dcd6625835231b9bb4f8083ec7580ceb77099L112-R112) [[3]](diffhunk://#diff-1e02ad39f9e022e4f760f87db84dcd6625835231b9bb4f8083ec7580ceb77099L161-R161)
* Adjusted the error response in `forttask/src/app/api/bill/totalNumber/route.ts` to return `Internal Server Error` with a 500 status code instead of `Invalid request` for the `GET` method.

### User-Facing Message Refinements:
* Clarified the 401 error message in `forttask/src/app/api/shoppingList/route.ts` to specify that the user must be logged in to create a shopping item rather than join a household.
* Improved the phrasing of 401 and 403 error messages in `forttask/src/app/api/shoppingList/totalNumber/route.ts` for better readability and consistency:
  - Changed "view the shopping list count" to "view shopping list count" in both scenarios where the user is not logged in or not a member of a household. [[1]](diffhunk://#diff-89754b238cd38bb9a9ab67aaddc4eed89ffd1e8de716ad507e1a62fe2f686e40L12-R12) [[2]](diffhunk://#diff-89754b238cd38bb9a9ab67aaddc4eed89ffd1e8de716ad507e1a62fe2f686e40L30-R30)